### PR TITLE
fix assertIsDefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -362,11 +362,11 @@ export function assertIsNotUndefined(
  * @param additionalMessage  further information on failure
  * @throws {Error}
  */
-export function assertIsDefined(
-  value: unknown,
+export function assertIsDefined<T>(
+  value: T,
   variableName?: string,
   additionalMessage?: string
-): asserts value is NonNullable<any> {
+): asserts value is NonNullable<T> {
   assert(
     isDefined(value),
     AssertionMessage(value, "defined", variableName, additionalMessage)


### PR DESCRIPTION
seems assertIsDefined seems to work correctly at runtime but the compile time type assertions see where inefficient.